### PR TITLE
fix: Update activation events for specific command trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "git-graph-2",
 	"displayName": "Git Graph 2",
-	"version": "1.32.0",
+	"version": "1.32.1",
 	"publisher": "hansu",
 	"author": {
 		"name": "Michael Hutchison",
@@ -36,7 +36,7 @@
 		"workspace"
 	],
 	"activationEvents": [
-		"*"
+		"onCommand:git-graph.view"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Refine activation events to trigger only on the `git-graph.view` command, improving performance and user experience. Update version to 1.32.1.