### PR TITLE
feat: Add option to copy short commit hash to clipboard

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -1278,6 +1278,13 @@ class GitGraphView {
 				}
 			},
 			{
+				title: 'Copy short Commit Hash to Clipboard',
+				visible: visibility.copySubject,
+				onClick: () => {
+					sendMessage({ command: 'copyToClipboard', type: 'Commit Hash', data: abbrevCommit(hash) });
+				}
+			},
+			{
 				title: 'Copy Commit Subject to Clipboard',
 				visible: visibility.copySubject,
 				onClick: () => {


### PR DESCRIPTION
Introduce a feature that allows users to copy the abbreviated commit hash to the clipboard, enhancing usability.

https://github.com/mhutchie/vscode-git-graph/pull/602