### PR TITLE
chore: Update release workflow for artifact upload with short retention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,18 @@ jobs:
       - name: package
         run: npm run package
 
-      - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+      # keep a short retention period for the artifact, as it is only for testing / personal use purposes
+      - name: Upload file
+        uses: actions/upload-artifact@v4
         with:
-          files: "./*.vsix"
+          path: ./*.vsix
+          retention-days: 7
+
+      # disabled for now, since it might breach the license agreement
+      # - name: Upload Release Asset
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     files: "./*.vsix"
 
       - name: Github Release
         run: npx changelogithub

--- a/README.md
+++ b/README.md
@@ -1,168 +1,173 @@
 # Git Graph extension for Visual Studio Code
 
+**Fork of https://github.com/hansu/vscode-git-graph**
+
+For **personal use only** because of the license restrictions.
+
 Fork of mhutchies Git Graph with further improvements.  
 Main improvements:
 
-* Added button to jump to HEAD (hansu#14)
-* Added collapse/expand buttons to commit diff view (hansu#6)
-* Resize column width without header (hansu#4)
-* Added author filter (hansu#1)
-* Added sticky header option (mhutchie#132)
+- Added button to jump to HEAD (hansu#14)
+- Added collapse/expand buttons to commit diff view (hansu#6)
+- Resize column width without header (hansu#4)
+- Added author filter (hansu#1)
+- Added sticky header option (mhutchie#132)
 
 ![Additions](https://github.com/hansu/vscode-git-graph/raw/master/resources/demo.gif)
 
 ## Features
 
-* Git Graph View:
-    * Display:
-        * Local & Remote Branches
-        * Local Refs: Heads, Tags & Remotes
-        * Uncommitted Changes
-    * Perform Git Actions (available by right clicking on a commit / branch / tag):
-        * Create, Checkout, Delete, Fetch, Merge, Pull, Push, Rebase, Rename & Reset Branches
-        * Add, Delete & Push Tags
-        * Checkout, Cherry Pick, Drop, Merge & Revert Commits
-        * Clean, Reset & Stash Uncommitted Changes
-        * Apply, Create Branch From, Drop & Pop Stashes
-        * View annotated tag details (name, email, date and message)
-        * Copy commit hashes, and branch, stash & tag names to the clipboard
-    * View commit details and file changes by clicking on a commit. On the Commit Details View you can:
-        * View the Visual Studio Code Diff of any file change by clicking on it.
-        * Open the current version of any file that was affected in the commit.
-        * Copy the path of any file that was affected in the commit to the clipboard.
-        * Click on any HTTP/HTTPS url in the commit body to open it in your default web browser.
-    * Compare any two commits by clicking on a commit, and then CTRL/CMD clicking on another commit. On the Commit Comparison View you can:
-        * View the Visual Studio Code Diff of any file change between the selected commits by clicking on it.
-        * Open the current version of any file that was affected between the selected commits.
-        * Copy the path of any file that was affected between the selected commits to the clipboard.
-    * Code Review - Keep track of which files you have reviewed in the Commit Details & Comparison Views.
-        * Code Review's can be performed on any commit, or between any two commits (not on Uncommitted Changes).
-        * When a Code Review is started, all files needing to be reviewed are bolded. When you view the diff / open a file, it will then be un-bolded.
-        * Code Reviews persist across Visual Studio Code sessions. They are automatically closed after 90 days of inactivity.
-    * View uncommitted changes, and compare the uncommitted changes with any commit.
-    * Hover over any commit vertex on the graph to see a tooltip indicating:
-        * Whether the commit is included in the HEAD.
-        * Which branches, tags and stashes include the commit. 
-    * Filter the branches shown in Git Graph using the 'Branches' dropdown menu. The options for filtering the branches are:
-        * Show All branches
-        * Select one or more branches to be viewed
-        * Select from a user predefined array of custom glob patterns (by setting `git-graph.customBranchGlobPatterns`)
-    * Fetch from Remote(s) _(available on the top control bar)_
-    * Find Widget allows you to quickly find one or more commits containing a specific phrase (in the commit message / date / author / hash, branch or tag names).
-    * Repository Settings Widget:
-        * Allows you to view, add, edit, delete, fetch & prune remotes of the repository.
-        * Configure "Issue Linking" - Converts issue numbers in commit messages into hyperlinks, that open the issue in your issue tracking system.
-        * Configure "Pull Request Creation" - Automates the opening and pre-filling of a Pull Request form, directly from a branches context menu.
-            * Support for the publicly hosted Bitbucket, GitHub and GitLab Pull Request providers is built-in.
-            * Custom Pull Request providers can be configured using the Extension Setting `git-graph.customPullRequestProviders` (e.g. for use with privately hosted Pull Request providers). Information on how to configure custom providers is available [here](https://github.com/hansu/vscode-git-graph/wiki/Configuring-a-custom-Pull-Request-Provider).
-        * Export your Git Graph Repository Configuration to a file that can be committed in the repository. It allows others working in the same repository to automatically use the same Git Graph configuration.
-    * Keyboard Shortcuts (available in the Git Graph View):
-        * `CTRL/CMD + F`: Open the Find Widget.
-        * `CTRL/CMD + H`: Scrolls the Git Graph View to be centered on the commit referenced by HEAD.
-        * `CTRL/CMD + R`: Refresh the Git Graph View.
-        * `CTRL/CMD + S`: Scrolls the Git Graph View to the first (or next) stash in the loaded commits.
-        * `CTRL/CMD + SHIFT + S`: Scrolls the Git Graph View to the last (or previous) stash in the loaded commits.
-        * When the Commit Details View is open on a commit:
-            * `Up` / `Down`: The Commit Details View will be opened on the commit directly above or below it on the Git Graph View.
-            * `CTRL/CMD + Up` / `CTRL/CMD + Down`: The Commit Details View will be opened on its child or parent commit on the same branch.
-                * If the Shift Key is also pressed (i.e. `CTRL/CMD + SHIFT + Up` / `CTRL/CMD + SHIFT + Down`), when branches or merges are encountered the alternative branch is followed.
-        * `Enter`: If a dialog is open, pressing enter submits the dialog, taking the primary (left) action.
-        * `Escape`: Closes the active dialog, context menu or the Commit Details View.
-    * Resize the width of each column, and show/hide the Date, Author & Commit columns.
-    * Common Emoji Shortcodes are automatically replaced with the corresponding emoji in commit messages (including all [gitmoji](https://gitmoji.carloscuesta.me/)). Custom Emoji Shortcode mappings can be defined in `git-graph.customEmojiShortcodeMappings`.
-* A broad range of configurable settings (e.g. graph style, branch colours, and more...). See the 'Extension Settings' section below for more information.
-* "Git Graph" launch button in the Status Bar
-* "Git Graph: View Git Graph" launch command in the Command Palette
+- Git Graph View:
+  - Display:
+    - Local & Remote Branches
+    - Local Refs: Heads, Tags & Remotes
+    - Uncommitted Changes
+  - Perform Git Actions (available by right clicking on a commit / branch / tag):
+    - Create, Checkout, Delete, Fetch, Merge, Pull, Push, Rebase, Rename & Reset Branches
+    - Add, Delete & Push Tags
+    - Checkout, Cherry Pick, Drop, Merge & Revert Commits
+    - Clean, Reset & Stash Uncommitted Changes
+    - Apply, Create Branch From, Drop & Pop Stashes
+    - View annotated tag details (name, email, date and message)
+    - Copy commit hashes, and branch, stash & tag names to the clipboard
+  - View commit details and file changes by clicking on a commit. On the Commit Details View you can:
+    - View the Visual Studio Code Diff of any file change by clicking on it.
+    - Open the current version of any file that was affected in the commit.
+    - Copy the path of any file that was affected in the commit to the clipboard.
+    - Click on any HTTP/HTTPS url in the commit body to open it in your default web browser.
+  - Compare any two commits by clicking on a commit, and then CTRL/CMD clicking on another commit. On the Commit Comparison View you can:
+    - View the Visual Studio Code Diff of any file change between the selected commits by clicking on it.
+    - Open the current version of any file that was affected between the selected commits.
+    - Copy the path of any file that was affected between the selected commits to the clipboard.
+  - Code Review - Keep track of which files you have reviewed in the Commit Details & Comparison Views.
+    - Code Review's can be performed on any commit, or between any two commits (not on Uncommitted Changes).
+    - When a Code Review is started, all files needing to be reviewed are bolded. When you view the diff / open a file, it will then be un-bolded.
+    - Code Reviews persist across Visual Studio Code sessions. They are automatically closed after 90 days of inactivity.
+  - View uncommitted changes, and compare the uncommitted changes with any commit.
+  - Hover over any commit vertex on the graph to see a tooltip indicating:
+    - Whether the commit is included in the HEAD.
+    - Which branches, tags and stashes include the commit.
+  - Filter the branches shown in Git Graph using the 'Branches' dropdown menu. The options for filtering the branches are:
+    - Show All branches
+    - Select one or more branches to be viewed
+    - Select from a user predefined array of custom glob patterns (by setting `git-graph.customBranchGlobPatterns`)
+  - Fetch from Remote(s) _(available on the top control bar)_
+  - Find Widget allows you to quickly find one or more commits containing a specific phrase (in the commit message / date / author / hash, branch or tag names).
+  - Repository Settings Widget:
+    - Allows you to view, add, edit, delete, fetch & prune remotes of the repository.
+    - Configure "Issue Linking" - Converts issue numbers in commit messages into hyperlinks, that open the issue in your issue tracking system.
+    - Configure "Pull Request Creation" - Automates the opening and pre-filling of a Pull Request form, directly from a branches context menu.
+      - Support for the publicly hosted Bitbucket, GitHub and GitLab Pull Request providers is built-in.
+      - Custom Pull Request providers can be configured using the Extension Setting `git-graph.customPullRequestProviders` (e.g. for use with privately hosted Pull Request providers). Information on how to configure custom providers is available [here](https://github.com/hansu/vscode-git-graph/wiki/Configuring-a-custom-Pull-Request-Provider).
+    - Export your Git Graph Repository Configuration to a file that can be committed in the repository. It allows others working in the same repository to automatically use the same Git Graph configuration.
+  - Keyboard Shortcuts (available in the Git Graph View):
+    - `CTRL/CMD + F`: Open the Find Widget.
+    - `CTRL/CMD + H`: Scrolls the Git Graph View to be centered on the commit referenced by HEAD.
+    - `CTRL/CMD + R`: Refresh the Git Graph View.
+    - `CTRL/CMD + S`: Scrolls the Git Graph View to the first (or next) stash in the loaded commits.
+    - `CTRL/CMD + SHIFT + S`: Scrolls the Git Graph View to the last (or previous) stash in the loaded commits.
+    - When the Commit Details View is open on a commit:
+      - `Up` / `Down`: The Commit Details View will be opened on the commit directly above or below it on the Git Graph View.
+      - `CTRL/CMD + Up` / `CTRL/CMD + Down`: The Commit Details View will be opened on its child or parent commit on the same branch.
+        - If the Shift Key is also pressed (i.e. `CTRL/CMD + SHIFT + Up` / `CTRL/CMD + SHIFT + Down`), when branches or merges are encountered the alternative branch is followed.
+    - `Enter`: If a dialog is open, pressing enter submits the dialog, taking the primary (left) action.
+    - `Escape`: Closes the active dialog, context menu or the Commit Details View.
+  - Resize the width of each column, and show/hide the Date, Author & Commit columns.
+  - Common Emoji Shortcodes are automatically replaced with the corresponding emoji in commit messages (including all [gitmoji](https://gitmoji.carloscuesta.me/)). Custom Emoji Shortcode mappings can be defined in `git-graph.customEmojiShortcodeMappings`.
+- A broad range of configurable settings (e.g. graph style, branch colours, and more...). See the 'Extension Settings' section below for more information.
+- "Git Graph" launch button in the Status Bar
+- "Git Graph: View Git Graph" launch command in the Command Palette
 
 ## Extension Settings
 
 Detailed information of all Git Graph settings is available [here](https://github.com/hansu/vscode-git-graph/wiki/Extension-Settings), including: descriptions, screenshots, default values and types.
 
 A summary of the Git Graph extension settings are:
-* **Commit Details View**:
-    * **Auto Center**: Automatically center the Commit Details View when it is opened.
-    * **File View**:
-        * **File Tree**:
-            * **Compact Folders**: Render the File Tree in the Commit Details View in a compacted form, such that folders with a single child folder are compressed into a single combined folder element.
-        * **Type**: Sets the default type of File View used in the Commit Details View.
-    * **Location**: Specifies where the Commit Details View is rendered in the Git Graph View.
-* **Context Menu Actions Visibility**: Customise which context menu actions are visible. For more information, see the documentation [here](https://github.com/hansu/vscode-git-graph/wiki/Extension-Settings#context-menu-actions-visibility).
-* **Custom Branch Glob Patterns**: An array of Custom Glob Patterns to be shown in the "Branches" dropdown. Example: `[{"name":"Feature Requests", "glob":"heads/feature/*"}]`
-* **Custom Emoji Shortcode Mappings**: An array of custom Emoji Shortcode mappings. Example: `[{"shortcode": ":sparkles:", "emoji":"✨"}]`
-* **Custom Pull Request Providers**: An array of custom Pull Request providers that can be used in the "Pull Request Creation" Integration. For information on how to configure this setting, see the documentation [here](https://github.com/hansu/vscode-git-graph/wiki/Configuring-a-custom-Pull-Request-Provider).
-* **Date**:
-    * **Format**: Specifies the date format to be used in the "Date" column on the Git Graph View.
-    * **Type**: Specifies the date type to be displayed in the "Date" column on the Git Graph View, either the author or commit date.
-* **Default Column Visibility**: An object specifying the default visibility of the Date, Author & Commit columns. Example: `{"Date": true, "Author": true, "Commit": true}`
-* **Dialog > \***: Set the default options on the following dialogs: Add Tag, Apply Stash, Cherry Pick, Create Branch, Delete Branch, Fetch into Local Branch, Fetch Remote, Merge, Pop Stash, Pull Branch, Rebase, Reset, and Stash Uncommitted Changes
-* **Enhanced Accessibility**: Visual file change A|M|D|R|U indicators in the Commit Details View for users with colour blindness. In the future, this setting will enable any additional accessibility related features of Git Graph that aren't enabled by default.
-* **File Encoding**: The character set encoding used when retrieving a specific version of repository files (e.g. in the Diff View). A list of all supported encodings can be found [here](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings).
-* **Graph**:
-    * **Colours**: Specifies the colours used on the graph.
-    * **Style**: Specifies the style of the graph.
-    * **Uncommitted Changes**: Specifies how the Uncommitted Changes are displayed on the graph.
-* **Integrated Terminal Shell**: Specifies the path and filename of the Shell executable to be used by the Visual Studio Code Integrated Terminal, when it is opened by Git Graph.
-* **Keyboard Shortcut > \***: Configures the keybindings used for all keyboard shortcuts in the Git Graph View.
-* **Markdown**: Parse and render a frequently used subset of inline Markdown formatting rules in commit messages and tag details (bold, italics, bold & italics, and inline code blocks).
-* **Max Depth Of Repo Search**: Specifies the maximum depth of subfolders to search when discovering repositories in the workspace.
-* **Open New Tab Editor Group**: Specifies the Editor Group where Git Graph should open new tabs, when performing the following actions from the Git Graph View: Viewing the Visual Studio Code Diff View, Opening a File, Viewing a File at a Specific Revision.
-* **Open to the Repo of the Active Text Editor Document**: Open the Git Graph View to the repository containing the active Text Editor document.
-* **Reference Labels**:
-    * **Alignment**: Specifies how branch and tag reference labels are aligned for each commit.
-    * **Combine Local and Remote Branch Labels**: Combine local and remote branch labels if they refer to the same branch, and are on the same commit.
-* **Repository**:
-    * **Commits**:
-        * **Fetch Avatars**: Fetch avatars of commit authors and committers.
-        * **Initial Load**: Specifies the number of commits to initially load.
-        * **Load More**: Specifies the number of additional commits to load when the "Load More Commits" button is pressed, or more commits are automatically loaded.
-        * **Load More Automatically**: When the view has been scrolled to the bottom, automatically load more commits if they exist (instead of having to press the "Load More Commits" button).
-        * **Mute**:
-            * **Commits that are not ancestors of HEAD**: Display commits that aren't ancestors of the checked-out branch / commit with a muted text color.
-            * **Merge Commits**: Display merge commits with a muted text color.
-        * **Order**: Specifies the order of commits on the Git Graph View. See [git log](https://git-scm.com/docs/git-log#_commit_ordering) for more information on each order option.
-        * **Show Signature Status**: Show the commit's signature status to the right of the Committer in the Commit Details View (only for signed commits). Hovering over the signature icon displays a tooltip with the signature details.
-    * **Fetch and Prune**: Before fetching from remote(s) using the Fetch button on the Git Graph View Control Bar, remove any remote-tracking references that no longer exist on the remote(s).
-    * **Fetch And Prune Tags**: Before fetching from remote(s) using the Fetch button on the Git Graph View Control Bar, remove any local tags that no longer exist on the remote(s).
-    * **Include Commits Mentioned By Reflogs**: Include commits only mentioned by reflogs in the Git Graph View (only applies when showing all branches).
-    * **On Load**:
-        * **Scroll To Head**: Automatically scroll the Git Graph View to be centered on the commit referenced by HEAD.
-        * **Show Checked Out Branch**: Show the checked out branch when a repository is loaded in the Git Graph View.
-        * **Show Specific Branches**: Show specific branches when a repository is loaded in the Git Graph View.
-    * **Only Follow First Parent**: Only follow the first parent of commits when discovering the commits to load in the Git Graph View. See [--first-parent](https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent) to find out more about this setting.
-    * **Show Commits Only Referenced By Tags**: Show Commits that are only referenced by tags in Git Graph.
-    * **Show Remote Branches**: Show Remote Branches in Git Graph by default.
-    * **Show Remote Heads**: Show Remote HEAD Symbolic References in Git Graph.
-    * **Show Stashes**: Show Stashes in Git Graph by default.
-    * **Show Tags**: Show Tags in Git Graph by default.
-    * **Show Uncommitted Changes**: Show uncommitted changes. If you work on large repositories, disabling this setting can reduce the load time of the Git Graph View.
-    * **Show Untracked Files**: Show untracked files when viewing the uncommitted changes. If you work on large repositories, disabling this setting can reduce the load time of the Git Graph View.
-    * **Sign**:
-        * **Commits**: Enables commit signing with GPG or X.509.
-        * **Tags**: Enables tag signing with GPG or X.509.
-    * **Use Mailmap**: Respect [.mailmap](https://git-scm.com/docs/git-check-mailmap#_mapping_authors) files when displaying author & committer names and email addresses.
-* **Repository Dropdown Order**: Specifies the order that repositories are sorted in the repository dropdown on the Git Graph View (only visible when more than one repository exists in the current Visual Studio Code Workspace).
-* **Retain Context When Hidden**: Specifies if the Git Graph view Visual Studio Code context is kept when the panel is no longer visible (e.g. moved to background tab). Enabling this setting will make Git Graph load significantly faster when switching back to the Git Graph tab, however has a higher memory overhead.
-* **Show Status Bar Item**: Show a Status Bar Item that opens the Git Graph View when clicked.
-* **Source Code Provider Integration Location**: Specifies where the "View Git Graph" action appears on the title of SCM Providers.
-* **Tab Icon Colour Theme**: Specifies the colour theme of the icon displayed on the Git Graph tab.
+
+- **Commit Details View**:
+  - **Auto Center**: Automatically center the Commit Details View when it is opened.
+  - **File View**:
+    - **File Tree**:
+      - **Compact Folders**: Render the File Tree in the Commit Details View in a compacted form, such that folders with a single child folder are compressed into a single combined folder element.
+    - **Type**: Sets the default type of File View used in the Commit Details View.
+  - **Location**: Specifies where the Commit Details View is rendered in the Git Graph View.
+- **Context Menu Actions Visibility**: Customise which context menu actions are visible. For more information, see the documentation [here](https://github.com/hansu/vscode-git-graph/wiki/Extension-Settings#context-menu-actions-visibility).
+- **Custom Branch Glob Patterns**: An array of Custom Glob Patterns to be shown in the "Branches" dropdown. Example: `[{"name":"Feature Requests", "glob":"heads/feature/*"}]`
+- **Custom Emoji Shortcode Mappings**: An array of custom Emoji Shortcode mappings. Example: `[{"shortcode": ":sparkles:", "emoji":"✨"}]`
+- **Custom Pull Request Providers**: An array of custom Pull Request providers that can be used in the "Pull Request Creation" Integration. For information on how to configure this setting, see the documentation [here](https://github.com/hansu/vscode-git-graph/wiki/Configuring-a-custom-Pull-Request-Provider).
+- **Date**:
+  - **Format**: Specifies the date format to be used in the "Date" column on the Git Graph View.
+  - **Type**: Specifies the date type to be displayed in the "Date" column on the Git Graph View, either the author or commit date.
+- **Default Column Visibility**: An object specifying the default visibility of the Date, Author & Commit columns. Example: `{"Date": true, "Author": true, "Commit": true}`
+- **Dialog > \***: Set the default options on the following dialogs: Add Tag, Apply Stash, Cherry Pick, Create Branch, Delete Branch, Fetch into Local Branch, Fetch Remote, Merge, Pop Stash, Pull Branch, Rebase, Reset, and Stash Uncommitted Changes
+- **Enhanced Accessibility**: Visual file change A|M|D|R|U indicators in the Commit Details View for users with colour blindness. In the future, this setting will enable any additional accessibility related features of Git Graph that aren't enabled by default.
+- **File Encoding**: The character set encoding used when retrieving a specific version of repository files (e.g. in the Diff View). A list of all supported encodings can be found [here](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings).
+- **Graph**:
+  - **Colours**: Specifies the colours used on the graph.
+  - **Style**: Specifies the style of the graph.
+  - **Uncommitted Changes**: Specifies how the Uncommitted Changes are displayed on the graph.
+- **Integrated Terminal Shell**: Specifies the path and filename of the Shell executable to be used by the Visual Studio Code Integrated Terminal, when it is opened by Git Graph.
+- **Keyboard Shortcut > \***: Configures the keybindings used for all keyboard shortcuts in the Git Graph View.
+- **Markdown**: Parse and render a frequently used subset of inline Markdown formatting rules in commit messages and tag details (bold, italics, bold & italics, and inline code blocks).
+- **Max Depth Of Repo Search**: Specifies the maximum depth of subfolders to search when discovering repositories in the workspace.
+- **Open New Tab Editor Group**: Specifies the Editor Group where Git Graph should open new tabs, when performing the following actions from the Git Graph View: Viewing the Visual Studio Code Diff View, Opening a File, Viewing a File at a Specific Revision.
+- **Open to the Repo of the Active Text Editor Document**: Open the Git Graph View to the repository containing the active Text Editor document.
+- **Reference Labels**:
+  - **Alignment**: Specifies how branch and tag reference labels are aligned for each commit.
+  - **Combine Local and Remote Branch Labels**: Combine local and remote branch labels if they refer to the same branch, and are on the same commit.
+- **Repository**:
+  - **Commits**:
+    - **Fetch Avatars**: Fetch avatars of commit authors and committers.
+    - **Initial Load**: Specifies the number of commits to initially load.
+    - **Load More**: Specifies the number of additional commits to load when the "Load More Commits" button is pressed, or more commits are automatically loaded.
+    - **Load More Automatically**: When the view has been scrolled to the bottom, automatically load more commits if they exist (instead of having to press the "Load More Commits" button).
+    - **Mute**:
+      - **Commits that are not ancestors of HEAD**: Display commits that aren't ancestors of the checked-out branch / commit with a muted text color.
+      - **Merge Commits**: Display merge commits with a muted text color.
+    - **Order**: Specifies the order of commits on the Git Graph View. See [git log](https://git-scm.com/docs/git-log#_commit_ordering) for more information on each order option.
+    - **Show Signature Status**: Show the commit's signature status to the right of the Committer in the Commit Details View (only for signed commits). Hovering over the signature icon displays a tooltip with the signature details.
+  - **Fetch and Prune**: Before fetching from remote(s) using the Fetch button on the Git Graph View Control Bar, remove any remote-tracking references that no longer exist on the remote(s).
+  - **Fetch And Prune Tags**: Before fetching from remote(s) using the Fetch button on the Git Graph View Control Bar, remove any local tags that no longer exist on the remote(s).
+  - **Include Commits Mentioned By Reflogs**: Include commits only mentioned by reflogs in the Git Graph View (only applies when showing all branches).
+  - **On Load**:
+    - **Scroll To Head**: Automatically scroll the Git Graph View to be centered on the commit referenced by HEAD.
+    - **Show Checked Out Branch**: Show the checked out branch when a repository is loaded in the Git Graph View.
+    - **Show Specific Branches**: Show specific branches when a repository is loaded in the Git Graph View.
+  - **Only Follow First Parent**: Only follow the first parent of commits when discovering the commits to load in the Git Graph View. See [--first-parent](https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent) to find out more about this setting.
+  - **Show Commits Only Referenced By Tags**: Show Commits that are only referenced by tags in Git Graph.
+  - **Show Remote Branches**: Show Remote Branches in Git Graph by default.
+  - **Show Remote Heads**: Show Remote HEAD Symbolic References in Git Graph.
+  - **Show Stashes**: Show Stashes in Git Graph by default.
+  - **Show Tags**: Show Tags in Git Graph by default.
+  - **Show Uncommitted Changes**: Show uncommitted changes. If you work on large repositories, disabling this setting can reduce the load time of the Git Graph View.
+  - **Show Untracked Files**: Show untracked files when viewing the uncommitted changes. If you work on large repositories, disabling this setting can reduce the load time of the Git Graph View.
+  - **Sign**:
+    - **Commits**: Enables commit signing with GPG or X.509.
+    - **Tags**: Enables tag signing with GPG or X.509.
+  - **Use Mailmap**: Respect [.mailmap](https://git-scm.com/docs/git-check-mailmap#_mapping_authors) files when displaying author & committer names and email addresses.
+- **Repository Dropdown Order**: Specifies the order that repositories are sorted in the repository dropdown on the Git Graph View (only visible when more than one repository exists in the current Visual Studio Code Workspace).
+- **Retain Context When Hidden**: Specifies if the Git Graph view Visual Studio Code context is kept when the panel is no longer visible (e.g. moved to background tab). Enabling this setting will make Git Graph load significantly faster when switching back to the Git Graph tab, however has a higher memory overhead.
+- **Show Status Bar Item**: Show a Status Bar Item that opens the Git Graph View when clicked.
+- **Source Code Provider Integration Location**: Specifies where the "View Git Graph" action appears on the title of SCM Providers.
+- **Tab Icon Colour Theme**: Specifies the colour theme of the icon displayed on the Git Graph tab.
 
 This extension consumes the following settings:
 
-* `git.path`: Specifies the path and filename of a portable Git installation.
+- `git.path`: Specifies the path and filename of a portable Git installation.
 
 ## Extension Commands
 
 This extension contributes the following commands:
 
-* `git-graph.view`: Git Graph: View Git Graph
-* `git-graph.addGitRepository`: Git Graph: Add Git Repository... _(used to add sub-repos to Git Graph)_
-* `git-graph.clearAvatarCache`: Git Graph: Clear Avatar Cache
-* `git-graph.endAllWorkspaceCodeReviews`: Git Graph: End All Code Reviews in Workspace
-* `git-graph.endSpecificWorkspaceCodeReview`: Git Graph: End a specific Code Review in Workspace... _(used to end a specific Code Review without having to first open it in the Git Graph View)_
-* `git-graph.fetch`: Git Graph: Fetch from Remote(s) _(used to open the Git Graph View and immediately run "Fetch from Remote(s)")_
-* `git-graph.removeGitRepository`: Git Graph: Remove Git Repository... _(used to remove repositories from Git Graph)_
-* `git-graph.resumeWorkspaceCodeReview`: Git Graph: Resume a specific Code Review in Workspace... _(used to open the Git Graph View to a Code Review that is already in progress)_
-* `git-graph.version`: Git Graph: Get Version Information
+- `git-graph.view`: Git Graph: View Git Graph
+- `git-graph.addGitRepository`: Git Graph: Add Git Repository... _(used to add sub-repos to Git Graph)_
+- `git-graph.clearAvatarCache`: Git Graph: Clear Avatar Cache
+- `git-graph.endAllWorkspaceCodeReviews`: Git Graph: End All Code Reviews in Workspace
+- `git-graph.endSpecificWorkspaceCodeReview`: Git Graph: End a specific Code Review in Workspace... _(used to end a specific Code Review without having to first open it in the Git Graph View)_
+- `git-graph.fetch`: Git Graph: Fetch from Remote(s) _(used to open the Git Graph View and immediately run "Fetch from Remote(s)")_
+- `git-graph.removeGitRepository`: Git Graph: Remove Git Repository... _(used to remove repositories from Git Graph)_
+- `git-graph.resumeWorkspaceCodeReview`: Git Graph: Resume a specific Code Review in Workspace... _(used to open the Git Graph View to a Code Review that is already in progress)_
+- `git-graph.version`: Git Graph: Get Version Information
 
 ## Release Notes
 
@@ -173,5 +178,6 @@ Detailed Release Notes are available [here](CHANGELOG.md).
 Thank you to all of the contributors that help with the development of Git Graph!
 
 Some of the icons used in Git Graph are from the following sources, please support them for their excellent work!
+
 - [GitHub Octicons](https://octicons.github.com/) ([License](https://github.com/primer/octicons/blob/master/LICENSE))
 - [Icons8](https://icons8.com/icon/pack/free-icons/ios11) ([License](https://icons8.com/license))


### PR DESCRIPTION
Revise the release workflow to utilize artifact upload with a retention period of 7 days, while temporarily disabling the previous release asset upload to comply with licensing.